### PR TITLE
feat: enable multi-application support

### DIFF
--- a/.changes/unreleased/Added-20260505-115607.yaml
+++ b/.changes/unreleased/Added-20260505-115607.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Support multi-applications via alias
+time: 2026-05-05T11:56:07.061979+02:00

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: mach-composer/check-changie-changes-action@main
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           args: --issues-exit-code=0 --timeout=5m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,20 +1,36 @@
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-  - asciicheck
-  - bodyclose
-  - contextcheck
-  - errcheck
-  - exhaustive
-  - exportloopref
-  - forcetypeassert
-  - goimports
-  - gosimple
-  - govet
-  - ineffassign
-  - predeclared
-  - staticcheck
-  - tenv
-  - typecheck
-  - unused
-  - whitespace
+    - asciicheck
+    - bodyclose
+    - contextcheck
+    - errcheck
+    - exhaustive
+    - forcetypeassert
+    - govet
+    - ineffassign
+    - predeclared
+    - staticcheck
+    - unused
+    - whitespace
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains the Algolia plugin for Mach Composer. It requires Mach 
 
 ## Usage
 
+### Single application
+
 ```yaml
 mach_composer:
   version: 1
@@ -22,4 +24,43 @@ sites:
       api_key: api-key
       app_id: app-id
 
+```
+
+### Multiple applications
+
+Use `applications` when a single Mach Composer site needs to configure multiple
+Algolia applications. The application `name` is linked to the component with the
+same name and must be a valid Terraform provider alias.
+
+```yaml
+mach_composer:
+  version: 1
+  plugins:
+    algolia:
+      source: mach-composer/algolia
+      version: 0.1.0
+
+global:
+  # ...
+
+sites:
+  - identifier: my-site
+
+    algolia:
+      applications:
+        - name: lab_digital
+          api_key: lab-digital-api-key
+          app_id: lab-digital-app-id
+        - name: mach_composer
+          api_key: mach-composer-api-key
+          app_id: mach-composer-app-id
+```
+
+Components named `lab_digital` and `mach_composer` will receive the matching
+aliased Algolia provider:
+
+```hcl
+providers = {
+  algolia = algolia.lab_digital
+}
 ```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Use `applications` when a single Mach Composer site needs to configure multiple
 Algolia applications. The application `name` is linked to the component with the
 same name and must be a valid Terraform provider alias.
 
+> [!WARNING]
+> Do not switch an existing site from single application configuration to
+> multiple applications without a migration. The Terraform resource keys differ
+> between the two modes, so switching directly would make Terraform delete the
+> existing configured Algolia data and recreate it under the new keys.
+
 ```yaml
 mach_composer:
   version: 1

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -5,7 +5,7 @@ tasks:
     cmd: golangci-lint run
 
   build:
-    cmd: goreleaser build --snapshot --single-target --rm-dist
+    cmd: goreleaser build --snapshot --single-target --clean
 
   test:
     cmd: go test -race ./...

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/mach-composer/mach-composer-plugin-algolia
 go 1.21
 
 require (
-	github.com/creasty/defaults v1.7.0
 	github.com/mach-composer/mach-composer-plugin-sdk v1.0.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmms
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/creasty/defaults v1.7.0 h1:eNdqZvc5B509z18lD8yc212CAqJNvfT1Jq6L8WowdBA=
-github.com/creasty/defaults v1.7.0/go.mod h1:iGzKe6pbEHnpMPtfDXZEr0NVxWnPTjb1bbDy08fPzYM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -1,0 +1,27 @@
+package internal
+
+import "fmt"
+
+type InvalidSiteConfigError struct {
+	msg string
+}
+
+func NewInvalidSiteConfigError(format string, a ...any) *InvalidSiteConfigError {
+	return &InvalidSiteConfigError{msg: fmt.Sprintf(format, a...)}
+}
+
+func (n *InvalidSiteConfigError) Error() string {
+	return n.msg
+}
+
+type NoApplicationConfigError struct {
+	msg string
+}
+
+func NewNoApplicationConfigError(format string, a ...any) *NoApplicationConfigError {
+	return &NoApplicationConfigError{msg: fmt.Sprintf(format, a...)}
+}
+
+func (n *NoApplicationConfigError) Error() string {
+	return n.msg
+}

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -2,13 +2,15 @@ package internal
 
 import (
 	"fmt"
+	"regexp"
 
-	"github.com/creasty/defaults"
 	"github.com/mach-composer/mach-composer-plugin-helpers/helpers"
 	"github.com/mach-composer/mach-composer-plugin-sdk/plugin"
 	"github.com/mach-composer/mach-composer-plugin-sdk/schema"
 	"github.com/mitchellh/mapstructure"
 )
+
+var terraformAliasPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 type Plugin struct {
 	environment string
@@ -67,8 +69,28 @@ func (p *Plugin) SetSiteConfig(site string, data map[string]any) error {
 		return err
 	}
 
-	if err := defaults.Set(&cfg); err != nil {
-		return err
+	hasSingleApplication := cfg.ApiKey != "" || cfg.AppId != ""
+	hasMultiApplication := cfg.IsMultiApplication()
+
+	if hasSingleApplication && hasMultiApplication {
+		return NewInvalidSiteConfigError("site %s cannot have both api_key/app_id and applications set", site)
+	}
+
+	if hasSingleApplication && (cfg.ApiKey == "" || cfg.AppId == "") {
+		return NewInvalidSiteConfigError("site %s must have both api_key and app_id set", site)
+	}
+
+	for _, application := range cfg.Applications {
+		if application.Name == "" || application.ApiKey == "" || application.AppId == "" {
+			return NewInvalidSiteConfigError("site %s applications must have name, api_key, and app_id set", site)
+		}
+		if !isValidTerraformAlias(application.Name) {
+			return NewInvalidSiteConfigError("site %s application %s must be a valid Terraform provider alias", site, application.Name)
+		}
+	}
+
+	if p.siteConfigs == nil {
+		p.siteConfigs = map[string]SiteConfig{}
 	}
 	p.siteConfigs[site] = cfg
 	return nil
@@ -89,24 +111,44 @@ func (p *Plugin) TerraformRenderResources(site string) (string, error) {
 		return "", nil
 	}
 
-	templateContext := struct {
-		ApiKey string
-		AppId  string
-	}{
-		ApiKey: cfg.ApiKey,
-		AppId:  cfg.AppId,
-	}
-
 	template := `
+		{{- if .IsMultiApplication }}
+		{{- range .Applications }}
+		provider "algolia" {
+			{{if ne .Name "algolia" }}{{ renderProperty "alias" .Name }}{{ end }}
+			{{ renderProperty "api_key" .ApiKey }}
+			{{ renderProperty "app_id" .AppId }}
+		}
+		{{- end }}
+		{{- else }}
 		provider "algolia" {
 			{{ renderProperty "api_key" .ApiKey }}
 			{{ renderProperty "app_id" .AppId }}
 		}
+		{{- end }}
 	`
-	return helpers.RenderGoTemplate(template, templateContext)
+	return helpers.RenderGoTemplate(template, cfg)
 }
 
-func (p *Plugin) RenderTerraformComponent(_ string, _ string) (*schema.ComponentSchema, error) {
+func (p *Plugin) RenderTerraformComponent(site string, component string) (*schema.ComponentSchema, error) {
+	cfg := p.getSiteConfig(site)
+	if cfg != nil && cfg.IsMultiApplication() {
+		application := cfg.GetApplicationConfig(component)
+		if application == nil {
+			return nil, NewNoApplicationConfigError("application %s not found in site %s. An application must exist with the same name as the component", component, site)
+		}
+
+		if component == "algolia" {
+			return &schema.ComponentSchema{}, nil
+		}
+
+		return &schema.ComponentSchema{
+			Providers: []string{
+				fmt.Sprintf("algolia = algolia.%s", component),
+			},
+		}, nil
+	}
+
 	result := &schema.ComponentSchema{
 		Providers: []string{
 			"algolia = algolia",
@@ -121,4 +163,8 @@ func (p *Plugin) getSiteConfig(site string) *SiteConfig {
 		return nil
 	}
 	return &cfg
+}
+
+func isValidTerraformAlias(value string) bool {
+	return terraformAliasPattern.MatchString(value)
 }

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -134,14 +134,21 @@ func (p *Plugin) RenderTerraformComponent(site string, component string) (*schem
 	cfg := p.getSiteConfig(site)
 	if cfg != nil && cfg.IsMultiApplication() {
 		application := cfg.GetApplicationConfig(component)
-		if application == nil {
-			return nil, NewNoApplicationConfigError("application %s not found in site %s. An application must exist with the same name as the component", component, site)
+		if application != nil {
+			return &schema.ComponentSchema{
+				Providers: []string{
+					fmt.Sprintf("algolia = algolia.%s", component),
+				},
+			}, nil
+		}
+
+		providers := make([]string, 0, len(cfg.Applications))
+		for _, application := range cfg.Applications {
+			providers = append(providers, fmt.Sprintf("algolia.%s = algolia.%s", application.Name, application.Name))
 		}
 
 		return &schema.ComponentSchema{
-			Providers: []string{
-				fmt.Sprintf("algolia = algolia.%s", component),
-			},
+			Providers: providers,
 		}, nil
 	}
 

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -115,7 +115,7 @@ func (p *Plugin) TerraformRenderResources(site string) (string, error) {
 		{{- if .IsMultiApplication }}
 		{{- range .Applications }}
 		provider "algolia" {
-			{{if ne .Name "algolia" }}{{ renderProperty "alias" .Name }}{{ end }}
+			{{ renderProperty "alias" .Name }}
 			{{ renderProperty "api_key" .ApiKey }}
 			{{ renderProperty "app_id" .AppId }}
 		}
@@ -136,10 +136,6 @@ func (p *Plugin) RenderTerraformComponent(site string, component string) (*schem
 		application := cfg.GetApplicationConfig(component)
 		if application == nil {
 			return nil, NewNoApplicationConfigError("application %s not found in site %s. An application must exist with the same name as the component", component, site)
-		}
-
-		if component == "algolia" {
-			return &schema.ComponentSchema{}, nil
 		}
 
 		return &schema.ComponentSchema{

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -1,12 +1,17 @@
 package internal
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/mach-composer/mach-composer-plugin-sdk/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func normalize(s string) string {
+	return strings.ToLower(strings.Join(strings.Fields(s), ""))
+}
 
 func TestRenderTerraformResources(t *testing.T) {
 	tests := []struct {
@@ -36,4 +41,196 @@ func TestRenderTerraformResources(t *testing.T) {
 			assert.Contains(t, result, `app_id = "1234"`)
 		})
 	}
+}
+
+func TestRenderTerraformResourcesMultiApplication(t *testing.T) {
+	p := NewAlgoliaPlugin()
+	err := p.SetSiteConfig("test-site", map[string]any{
+		"applications": []any{
+			map[string]any{
+				"name":    "lab_digital",
+				"api_key": "lab-digital-key",
+				"app_id":  "lab-digital-app",
+			},
+			map[string]any{
+				"name":    "mach_composer",
+				"api_key": "mach-composer-key",
+				"app_id":  "mach-composer-app",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	result, err := p.RenderTerraformResources("test-site")
+	require.NoError(t, err)
+
+	assert.Equal(t, normalize(`
+		provider "algolia" {
+			alias   = "lab_digital"
+			api_key = "lab-digital-key"
+			app_id  = "lab-digital-app"
+		}
+
+		provider "algolia" {
+			alias   = "mach_composer"
+			api_key = "mach-composer-key"
+			app_id  = "mach-composer-app"
+		}
+	`), normalize(result))
+}
+
+func TestRenderTerraformResourcesMultiApplicationDefaultProvider(t *testing.T) {
+	p := NewAlgoliaPlugin()
+	err := p.SetSiteConfig("test-site", map[string]any{
+		"applications": []any{
+			map[string]any{
+				"name":    "algolia",
+				"api_key": "default-key",
+				"app_id":  "default-app",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	result, err := p.RenderTerraformResources("test-site")
+	require.NoError(t, err)
+
+	assert.Equal(t, normalize(`
+		provider "algolia" {
+			api_key = "default-key"
+			app_id  = "default-app"
+		}
+	`), normalize(result))
+}
+
+func TestRenderTerraformComponentSingleApplication(t *testing.T) {
+	p := NewAlgoliaPlugin()
+	err := p.SetSiteConfig("test-site", map[string]any{
+		"api_key": "foobar",
+		"app_id":  "1234",
+	})
+	require.NoError(t, err)
+
+	result, err := p.RenderTerraformComponent("test-site", "component")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"algolia = algolia"}, result.Providers)
+}
+
+func TestRenderTerraformComponentMultiApplication(t *testing.T) {
+	p := NewAlgoliaPlugin()
+	err := p.SetSiteConfig("test-site", map[string]any{
+		"applications": []any{
+			map[string]any{
+				"name":    "lab_digital",
+				"api_key": "lab-digital-key",
+				"app_id":  "lab-digital-app",
+			},
+			map[string]any{
+				"name":    "mach_composer",
+				"api_key": "mach-composer-key",
+				"app_id":  "mach-composer-app",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	result, err := p.RenderTerraformComponent("test-site", "lab_digital")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"algolia = algolia.lab_digital"}, result.Providers)
+}
+
+func TestRenderTerraformComponentMultiApplicationDefaultProvider(t *testing.T) {
+	p := NewAlgoliaPlugin()
+	err := p.SetSiteConfig("test-site", map[string]any{
+		"applications": []any{
+			map[string]any{
+				"name":    "algolia",
+				"api_key": "default-key",
+				"app_id":  "default-app",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	result, err := p.RenderTerraformComponent("test-site", "algolia")
+	require.NoError(t, err)
+
+	assert.Empty(t, result.Providers)
+}
+
+func TestRenderTerraformComponentMultiApplicationNotFound(t *testing.T) {
+	p := NewAlgoliaPlugin()
+	err := p.SetSiteConfig("test-site", map[string]any{
+		"applications": []any{
+			map[string]any{
+				"name":    "lab_digital",
+				"api_key": "lab-digital-key",
+				"app_id":  "lab-digital-app",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var customErr = &NoApplicationConfigError{}
+
+	_, err = p.RenderTerraformComponent("test-site", "mach_composer")
+	assert.ErrorAs(t, err, &customErr)
+}
+
+func TestSetSiteConfigEmpty(t *testing.T) {
+	p := NewAlgoliaPlugin()
+
+	err := p.SetSiteConfig("test-site", map[string]any{})
+	assert.NoError(t, err)
+
+	resources, err := p.RenderTerraformResources("test-site")
+	require.NoError(t, err)
+	assert.Empty(t, resources)
+}
+
+func TestSetSiteConfigPartialSingleApplication(t *testing.T) {
+	p := NewAlgoliaPlugin()
+
+	var customErr = &InvalidSiteConfigError{}
+
+	err := p.SetSiteConfig("test-site", map[string]any{
+		"api_key": "foobar",
+	})
+	assert.ErrorAs(t, err, &customErr)
+}
+
+func TestSetSiteConfigSingleAndMultiApplication(t *testing.T) {
+	p := NewAlgoliaPlugin()
+
+	var customErr = &InvalidSiteConfigError{}
+
+	err := p.SetSiteConfig("test-site", map[string]any{
+		"api_key": "foobar",
+		"app_id":  "1234",
+		"applications": []any{
+			map[string]any{
+				"name":    "lab_digital",
+				"api_key": "lab-digital-key",
+				"app_id":  "lab-digital-app",
+			},
+		},
+	})
+	assert.ErrorAs(t, err, &customErr)
+}
+
+func TestSetSiteConfigInvalidApplicationAlias(t *testing.T) {
+	p := NewAlgoliaPlugin()
+
+	err := p.SetSiteConfig("test-site", map[string]any{
+		"applications": []any{
+			map[string]any{
+				"name":    "lab-digital",
+				"api_key": "lab-digital-key",
+				"app_id":  "lab-digital-app",
+			},
+		},
+	})
+	assert.Error(t, err)
 }

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -126,14 +126,22 @@ func TestRenderTerraformComponentMultiApplicationNotFound(t *testing.T) {
 				"api_key": "lab-digital-key",
 				"app_id":  "lab-digital-app",
 			},
+			map[string]any{
+				"name":    "mach_composer",
+				"api_key": "mach-composer-key",
+				"app_id":  "mach-composer-app",
+			},
 		},
 	})
 	require.NoError(t, err)
 
-	var customErr = &NoApplicationConfigError{}
+	result, err := p.RenderTerraformComponent("test-site", "shared_config")
+	require.NoError(t, err)
 
-	_, err = p.RenderTerraformComponent("test-site", "mach_composer")
-	assert.ErrorAs(t, err, &customErr)
+	assert.Equal(t, []string{
+		"algolia.lab_digital = algolia.lab_digital",
+		"algolia.mach_composer = algolia.mach_composer",
+	}, result.Providers)
 }
 
 func TestSetSiteConfigEmpty(t *testing.T) {

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -79,30 +79,6 @@ func TestRenderTerraformResourcesMultiApplication(t *testing.T) {
 	`), normalize(result))
 }
 
-func TestRenderTerraformResourcesMultiApplicationDefaultProvider(t *testing.T) {
-	p := NewAlgoliaPlugin()
-	err := p.SetSiteConfig("test-site", map[string]any{
-		"applications": []any{
-			map[string]any{
-				"name":    "algolia",
-				"api_key": "default-key",
-				"app_id":  "default-app",
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	result, err := p.RenderTerraformResources("test-site")
-	require.NoError(t, err)
-
-	assert.Equal(t, normalize(`
-		provider "algolia" {
-			api_key = "default-key"
-			app_id  = "default-app"
-		}
-	`), normalize(result))
-}
-
 func TestRenderTerraformComponentSingleApplication(t *testing.T) {
 	p := NewAlgoliaPlugin()
 	err := p.SetSiteConfig("test-site", map[string]any{
@@ -139,25 +115,6 @@ func TestRenderTerraformComponentMultiApplication(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"algolia = algolia.lab_digital"}, result.Providers)
-}
-
-func TestRenderTerraformComponentMultiApplicationDefaultProvider(t *testing.T) {
-	p := NewAlgoliaPlugin()
-	err := p.SetSiteConfig("test-site", map[string]any{
-		"applications": []any{
-			map[string]any{
-				"name":    "algolia",
-				"api_key": "default-key",
-				"app_id":  "default-app",
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	result, err := p.RenderTerraformComponent("test-site", "algolia")
-	require.NoError(t, err)
-
-	assert.Empty(t, result.Providers)
 }
 
 func TestRenderTerraformComponentMultiApplicationNotFound(t *testing.T) {

--- a/internal/schemas/site-config.json
+++ b/internal/schemas/site-config.json
@@ -1,17 +1,43 @@
 {
-    "type": "object",
-    "description": "algolia configuration.",
-    "additionalProperties": false,
-    "required": [
-        "api_key",
-        "app_id"
-    ],
-    "properties": {
-        "api_key": {
+  "type": "object",
+  "description": "algolia configuration.",
+  "additionalProperties": false,
+  "properties": {
+    "api_key": {
+      "description": "The Algolia API key. Either this and app_id must be set, or applications must be set.",
+      "type": "string"
+    },
+    "app_id": {
+      "description": "The Algolia application ID. Either this and api_key must be set, or applications must be set.",
+      "type": "string"
+    },
+    "applications": {
+      "description": "Algolia applications to use. Either this must be set, or api_key and app_id must be set.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "api_key",
+          "app_id"
+        ],
+        "properties": {
+          "name": {
+            "description": "The application name. Will be linked to the component with the same name and must be a valid Terraform provider alias.",
+            "type": "string",
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+          },
+          "api_key": {
+            "description": "The Algolia API key.",
             "type": "string"
-        },
-        "app_id": {
+          },
+          "app_id": {
+            "description": "The Algolia application ID.",
             "type": "string"
+          }
         }
+      }
     }
+  }
 }

--- a/internal/types.go
+++ b/internal/types.go
@@ -1,6 +1,26 @@
 package internal
 
 type SiteConfig struct {
+	ApiKey       string              `mapstructure:"api_key"`
+	AppId        string              `mapstructure:"app_id"`
+	Applications []ApplicationConfig `mapstructure:"applications"`
+}
+
+type ApplicationConfig struct {
+	Name   string `mapstructure:"name"`
 	ApiKey string `mapstructure:"api_key"`
 	AppId  string `mapstructure:"app_id"`
+}
+
+func (s *SiteConfig) IsMultiApplication() bool {
+	return len(s.Applications) > 0
+}
+
+func (s *SiteConfig) GetApplicationConfig(name string) *ApplicationConfig {
+	for _, application := range s.Applications {
+		if application.Name == name {
+			return &application
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
I've tried implementing a multi-application strategy however that didn't seemed to be supported yet. I've aligned with the https://github.com/mach-composer/mach-composer-plugin-amplience setup and tried to implement the same logic.

# Changes

- Added a new feature to support multi-application strategy